### PR TITLE
Added a check before saving highlighted atoms

### DIFF
--- a/metis/metis.py
+++ b/metis/metis.py
@@ -345,7 +345,10 @@ class Metis(QtWidgets.QMainWindow):
             )
 
     def gatherSelectedAtoms(self):
-        self.backend.atom_selection = self.editor.selectedAtoms
+        if len(self.editor.selectedAtoms) > 0:
+            self.backend.atom_selection = self.editor.selectedAtoms
+        else:
+            self.backend.atom_selection = []
 
     def switchLiability(self, liability: str):
         print(f"Switching Liability: {self.backend.current_liability} -> {liability}")


### PR DESCRIPTION
An issue can occur where the atoms highlighted of on atoms are carrying over to the next molecule.
This fix, fixed the issue. However, the issue should not occur even without the fix. 