### PR TITLE
pinning rdEditor for last PySide2 version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "cairosvg",
   "pydantic",
   "pyyaml",
-  "rdeditor",
+  "rdeditor==0.2.0.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
Released 0.2.0.1 as final for pyside2. Can set it for >0.2.0.1, once I got the pyside6 version out and you have switched as well.